### PR TITLE
Publish JaCoCo coverage to GitHub Pages

### DIFF
--- a/.github/workflows/coverage-pages.yml
+++ b/.github/workflows/coverage-pages.yml
@@ -1,0 +1,60 @@
+name: Publish coverage (JaCoCo) to GitHub Pages
+
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: 'maven'
+
+      - name: Build & test (generate coverage data)
+        run: |
+          mvn -B -DskipITs verify
+          # POM に jacoco:report を verify バインドしていない場合の保険
+          mvn -B jacoco:report
+
+      - name: Prepare Pages artifact
+        run: |
+          # 集約レポートに対応（存在すれば jacoco にリネーム）
+          test -d target/site/jacoco-aggregate && mv target/site/jacoco-aggregate target/site/jacoco || true
+          # Jekyll 無効化（アンダースコア付ファイル対策）
+          mkdir -p target/site/jacoco
+          touch target/site/jacoco/.nojekyll
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: target/site/jacoco
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4
+


### PR DESCRIPTION
  - 変更点                                                                                                                                                                                                     
      - 新規ワークフロー .github/workflows/coverage-pages.yml を追加。                                                                                                                                         
      - push: main と workflow_dispatch をトリガーに実行。                                                                                                                                                     
      - mvn verify 実行後に jacoco:report を明示し、target/site/jacoco（または jacoco-aggregate）を Pages へデプロイ。                                                                                         
      - Pages デプロイに必要な最小権限（pages:write, id-token:write）をワークフロー単位で付与。                                                                                                                
      - 競合抑止のため concurrency: { group: pages } を設定。          